### PR TITLE
fix: link error on window 11

### DIFF
--- a/src/modules/audio_device/win/audio_device_core_win.h
+++ b/src/modules/audio_device/win/audio_device_core_win.h
@@ -299,10 +299,9 @@ class AudioDeviceWindowsCore : public AudioDeviceGeneric,
     return S_OK;
   }
 
-  HRESULT __stdcall OnDefaultDeviceChanged(
-      EDataFlow flow,
-      ERole role,
-      LPCWSTR pwstrDefaultDeviceId) override;
+  HRESULT __stdcall OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR pwstrDefaultDeviceId) override{
+    return S_OK;
+  };
 
   HRESULT __stdcall OnPropertyValueChanged(LPCWSTR pwstrDeviceId,
                                            const PROPERTYKEY key) override {


### PR DESCRIPTION
Fixed link error for use ok-rtc on windows.

OS: win 11
platform toolset: Visual Studio 2022 (v143)


